### PR TITLE
fix(packaging): `redis` module is required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
@@ -8,7 +8,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["configalchemy"]
+requirements = ["configalchemy", "redis"]
 
 setup_requirements = []
 


### PR DESCRIPTION
I found the following code errored out with a message that no `redis`
module was available:

```python
from cache_alchemy import memory_cache
from cache_alchemy.config import DefaultConfig

class CacheConfig(DefaultConfig):
    CACHE_ALCHEMY_MEMORY_BACKEND = "cache_alchemy.backends.memory.MemoryCache"

config = CacheConfig()
```